### PR TITLE
Scan /testApp for npm updates; allow axemclion through the gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/testApp"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-gate.yml
+++ b/.github/workflows/dependabot-gate.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - name: Block non-Dependabot PRs
         run: |
-          if [ "${{ github.actor }}" != "dependabot[bot]" ]; then
-            echo "This repository only accepts PRs from Dependabot."
+          if [ "${{ github.actor }}" != "dependabot[bot]" ] && [ "${{ github.actor }}" != "axemclion" ]; then
+            echo "This repository only accepts PRs from Dependabot (or axemclion, for cases Dependabot can't auto-fix, e.g. deeply nested transitive-dependency alerts)."
             exit 1
           fi
-          echo "PR is from Dependabot, allowed."
+          echo "PR is allowed."


### PR DESCRIPTION
## Summary
- Adds a second `npm` ecosystem entry to `dependabot.yml` scoped to `/testApp`, so Dependabot's update job actually scans that directory. It currently only scans `/`, so the 66 alerts living in `testApp/package-lock.json` (of 80 total in this repo) have never had a chance to get an automated fix PR - not because they're unfixable, but because Dependabot was never configured to look there. `npm audit` shows ~76% of them have a clean, non-breaking fix available.
- Adds a scoped gate exception for `axemclion` in `dependabot-gate.yml`, matching `axe-demo/seamcarving`/`axe-demo/conference`, for the remaining alerts Dependabot genuinely can't auto-fix (no-fix-available or breaking-change-only cases).

## Test plan
- [x] YAML is valid, mirrors the existing root npm entry
- [x] CI `test` job passes
- Next: watch whether Dependabot opens PRs for `/testApp` on its next scheduled run (or trigger manually via Insights -> Dependency graph -> Dependabot)